### PR TITLE
url scheme changed at nvidia

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ nvidia_driver_install: yes
 NVIDIA driver version:
 
 ```yml
-nvidia_driver_version: '387.22'
+nvidia_driver_version: '390.30'
 ```
 
 The download directory to which the driver installation package will be downloaded:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-nvidia_driver_version: '387.22'
+nvidia_driver_version: '390.30'
 
 nvidia_driver_install: yes
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,6 @@ nvidia_driver_download_dir: '/var/cache/nvidia'
 
 nvidia_driver_build_remove_gcc: no
 
-nvidia_driver_base_url: 'http://us.download.nvidia.com/XFree86'
+nvidia_driver_base_url: 'http://us.download.nvidia.com/tesla'
 
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,12 +1,12 @@
 ---
 
-nvidia_driver_base_url: 'http://us.download.nvidia.com/XFree86'
+nvidia_driver_base_url: 'http://us.download.nvidia.com/tesla'
 
 nvidia_driver_arch: '{{ ansible_system }}-{{ ansible_architecture }}'
 
 nvidia_driver_filename: 'NVIDIA-{{ nvidia_driver_arch }}-{{ nvidia_driver_version }}.run'
 
-nvidia_driver_url: '{{ nvidia_driver_base_url }}/{{ nvidia_driver_arch }}/{{ nvidia_driver_version }}/{{ nvidia_driver_filename }}'
+nvidia_driver_url: '{{ nvidia_driver_base_url }}/{{ nvidia_driver_version }}/{{ nvidia_driver_filename }}'
 
 nvidia_driver_file: '{{ nvidia_driver_download_dir }}/{{ nvidia_driver_filename }}'
 


### PR DESCRIPTION
- needed it for frontend2 (no active nvidia driver since 8th october)
- successfully tested on eve
- this role is just awesome 