### PR TITLE
Query the installed driver version correctly

### DIFF
--- a/tasks/nvidia-driver.yml
+++ b/tasks/nvidia-driver.yml
@@ -13,10 +13,7 @@
     state: absent
 
 - name: check if nvidia driver is installed
-  shell: |
-    set -o pipefail
-    nvidia-modprobe --version |
-    grep -oP 'version \K[[:digit:]]+\.[[:digit:]]+'
+  command: nvidia-smi --query-gpu=driver_version --format=csv,noheader
   register: nvidia_driver_installed_version
   check_mode: no
   changed_when: >-


### PR DESCRIPTION
Most recent driver versions usually have triple digits, but the current grep command only accounts for the driver being two digits long, so setting nvidia_driver_version to "512.125.06" would always attempt to install the driver again because the last digit is truncated.

With the nvidia-smi command it is easier to fetch the version.